### PR TITLE
Fix encoding issues inside the input field

### DIFF
--- a/src/burp/BurpExtender.java
+++ b/src/burp/BurpExtender.java
@@ -79,7 +79,7 @@ public class BurpExtender implements IBurpExtender, ITab, IMessageEditorTabFacto
 			public void actionPerformed(ActionEvent e) {
 				IHttpRequestResponse[] msgs = invoc.getSelectedMessages();
 				if (msgs != null && msgs.length > 0) {
-					view.getIncomingRecipePanel().setInput(new String(msgs[0].getResponse()));
+					view.getIncomingRecipePanel().setInput(msgs[0].getResponse());
 				}
 			}
 		});
@@ -89,7 +89,7 @@ public class BurpExtender implements IBurpExtender, ITab, IMessageEditorTabFacto
 			public void actionPerformed(ActionEvent e) {
 				IHttpRequestResponse[] msgs = invoc.getSelectedMessages();
 				if (msgs != null && msgs.length > 0) {
-					view.getOutgoingRecipePanel().setInput(new String(msgs[0].getRequest()));
+					view.getOutgoingRecipePanel().setInput(msgs[0].getRequest());
 				}
 
 			}
@@ -100,7 +100,7 @@ public class BurpExtender implements IBurpExtender, ITab, IMessageEditorTabFacto
 			public void actionPerformed(ActionEvent e) {
 				IHttpRequestResponse[] msgs = invoc.getSelectedMessages();
 				if (msgs != null && msgs.length > 0) {
-					view.getFormatRecipePanel().setInput(new String(msgs[0].getRequest()));
+					view.getFormatRecipePanel().setInput(msgs[0].getRequest());
 				}
 			}
 		});

--- a/src/de/usd/cstchef/view/RecipePanel.java
+++ b/src/de/usd/cstchef/view/RecipePanel.java
@@ -297,8 +297,8 @@ public class RecipePanel extends JPanel implements ChangeListener {
 		}
 	}
 	
-	public void setInput(String input) {
-		this.inputText.setMessage(input.getBytes(), false);
+	public void setInput(byte[] input) {
+		this.inputText.setMessage(input, false);
 		this.bake(false);
 	}
 


### PR DESCRIPTION
The current approach to paste the request into the CSTC input field casts the received request object from a byte array to a string. Upon copying it into the UI input field, it expects again a bytes array. This back and forth conversion will try to encode binary blobs leading to malformed requests. As all functions expect to work with byte arrays the cast to a string can be removed to maintain the original requests structure.

