### PR TITLE
Merge develop into master

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [1.1.1] - 2020-05-20
+
+### Changed
+
+* The variable replace function used ``replaceAll`` which caused problems with the new variable
+  prefix ``$``. This was changed to ``replace``, as we don't need regex for variable replacement.
+* The ``pom.xml`` of the project now specifies an explicit file encoding. This should make the build
+  platform independent.
+
+
 ## [1.1.0] - 2020-05-20
 
 ### Added

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>de.usd.CSTC</groupId>
   <artifactId>CSTC</artifactId>
-  <version>1.1.0</version>
+  <version>1.1.1</version>
   <name>CSTC</name>
   <description>CSTC</description>
   <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -5,6 +5,9 @@
   <version>1.1.0</version>
   <name>CSTC</name>
   <description>CSTC</description>
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
   <build>
     <sourceDirectory>src</sourceDirectory>
     <resources>

--- a/src/de/usd/cstchef/Utils.java
+++ b/src/de/usd/cstchef/Utils.java
@@ -124,7 +124,7 @@ public class Utils {
 		HashMap<String, byte[]> variables = VariableStore.getInstance().getVariables();
 		for (Entry<String, byte[]> entry : variables.entrySet()) {
 			// TODO this is easy, but very bad, how to do this right?
-			text = text.replaceAll("$" + entry.getKey(), new String(entry.getValue()));
+			text = text.replace("$" + entry.getKey(), new String(entry.getValue()));
 		}
 
 		return text;


### PR DESCRIPTION
The change of the variable prefix to ``$`` caused an issue inside the variable replace function. This function used ``replaceAll``, where a single ``$`` causes invalid regular expressions. This should be fixed immediately, and therefore we need another push to master.