### PR TITLE
Improve Operation 'random': Add min/max and formatting

### DIFF
--- a/src/de/usd/cstchef/operations/utils/RandomNumber.java
+++ b/src/de/usd/cstchef/operations/utils/RandomNumber.java
@@ -1,8 +1,11 @@
 package de.usd.cstchef.operations.utils;
 
 import java.security.SecureRandom;
+import java.text.NumberFormat;
 
+import javax.swing.JSeparator;
 import javax.swing.JTextField;
+import javax.swing.SwingConstants;
 
 import de.usd.cstchef.operations.Operation;
 import de.usd.cstchef.operations.Operation.OperationInfos;
@@ -11,25 +14,99 @@ import de.usd.cstchef.operations.OperationCategory;
 @OperationInfos(name = "Random Number", category = OperationCategory.UTILS, description = "Generate a random number.")
 public class RandomNumber extends Operation {
 
-	private JTextField maximum;
+	// input fields for minimum/maximum
+	private JTextField textFieldMinimum;
+	private JTextField textFieldMaximum;
+	
+	// input fields for formatting
+	private JTextField textFieldFormatMinIntDigits;
+	private JTextField textFieldFormatMaxIntDigits;
+	private JTextField textFieldFormatMinFracDigits;
+	private JTextField textFieldFormatMaxFracDigits;
+	
+	private final static SecureRandom secRand = new SecureRandom();
+	private static NumberFormat numberFormatter = NumberFormat.getInstance();
+	
+	/**
+	 * Helper to parse Integer from String and set default if it fails
+	 * @param numberStr A string representing a number
+	 * @param defaultValue default value if parsing fails
+	 * @return
+	 */
+	private int parseInt(String numberStr, int defaultValue) {
+		try {
+			int intValue = Integer.valueOf(numberStr);
+			return intValue;
+		}catch (Exception e) {
+			return defaultValue;
+		}
+	}
 
 	@Override
 	protected byte[] perform(byte[] input) throws Exception {
+				
+		// get Bounds from user input
+		int boundMin = parseInt(this.textFieldMinimum.getText(), 0);
+		int boundMax = parseInt(this.textFieldMaximum.getText(), Integer.MAX_VALUE);
 
-		SecureRandom secRand = new SecureRandom();
-		try {
-			int bound = Integer.valueOf(this.maximum.getText()) + 1;
-			int random = Math.abs(secRand.nextInt(bound));
-			return String.valueOf(random).getBytes();
-		} catch( Exception e ) {
-			int random = Math.abs(secRand.nextInt());
-			return String.valueOf(random).getBytes();
+		// prepare formatter
+		int minIntDigits = parseInt(this.textFieldFormatMinIntDigits.getText(), 1);
+		numberFormatter.setMinimumIntegerDigits(minIntDigits);
+
+		int maxIntDigits = parseInt(this.textFieldFormatMaxIntDigits.getText(), 99);
+		numberFormatter.setMaximumIntegerDigits(maxIntDigits);
+
+		int minFracDigits = parseInt(this.textFieldFormatMinFracDigits.getText(), 0);
+		numberFormatter.setMinimumFractionDigits(minFracDigits);
+
+		int maxFracDigits = parseInt(this.textFieldFormatMaxFracDigits.getText(), 0);
+		numberFormatter.setMaximumFractionDigits(maxFracDigits);
+
+		numberFormatter.setGroupingUsed(false);
+		
+		// generate random numbers and format them
+		if(maxFracDigits == 0) {
+			// use int mode
+			int randomValue = secRand.nextInt(boundMax - boundMin + 1) + boundMin;
+			return numberFormatter.format(randomValue).getBytes();
+		} else {
+			// use double mode
+			double randomValue = boundMin + (boundMax - boundMin) * secRand.nextDouble();
+			return numberFormatter.format(randomValue).getBytes();
 		}
 	}
 
 	public void createUI() {
-		this.maximum = new JTextField();
-		this.addUIElement("Maximum Number", this.maximum);
+		
+		// fields for min/max
+		this.textFieldMinimum = new JTextField();
+		this.textFieldMinimum.setText("0");
+		this.addUIElement("Minimum Number", this.textFieldMinimum);
+		
+		this.textFieldMaximum = new JTextField();
+		this.textFieldMaximum.setText("9999");
+		this.addUIElement("Maximum Number", this.textFieldMaximum);
+		
+		// use a separator
+		JSeparator separator = new JSeparator(SwingConstants.HORIZONTAL);
+		this.addUIElement(null, separator);
+		
+		// fields for formatting: Integer digits
+		this.textFieldFormatMinIntDigits = new JTextField();
+		this.textFieldFormatMinIntDigits.setText("1");
+		this.addUIElement("Min integer digits", this.textFieldFormatMinIntDigits);
+		
+		this.textFieldFormatMaxIntDigits = new JTextField();
+		this.textFieldFormatMaxIntDigits.setText("99");
+		this.addUIElement("Max integer digits", this.textFieldFormatMaxIntDigits);
+		
+		// fields for formatting: fraction digits
+		this.textFieldFormatMinFracDigits = new JTextField();
+		this.textFieldFormatMinFracDigits.setText("0");
+		this.addUIElement("Min fraction digits", this.textFieldFormatMinFracDigits);
+		
+		this.textFieldFormatMaxFracDigits = new JTextField();
+		this.textFieldFormatMaxFracDigits.setText("0");
+		this.addUIElement("Max fraction digits", this.textFieldFormatMaxFracDigits);
 	}
-
 }


### PR DESCRIPTION
This improves the random operation by adding more options:

Option Min/Max to adjust the minimum/maximum value. (self explanatory)

Additional integer formatting options:

- set min/max integer digits
- set min/max fraction digits

This allows, for instance, to generate random values with a static length.

Note: If `max fraction digits = 0` is used, we use Integer instead of Double, to get a better distribution.


# Screenshots:

## Before:

![image](https://user-images.githubusercontent.com/4031504/106025622-37746500-60c9-11eb-9307-6b838d1fee38.png)

## After:

![image](https://user-images.githubusercontent.com/4031504/106025724-4fe47f80-60c9-11eb-8998-9589b02e4be7.png)
