### PR TITLE
Improve Filter Selection Window

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ buildNumber.properties
 .classpath
 .project
 .settings/
+*/launch.json

--- a/src/main/java/burp/BurpExtender.java
+++ b/src/main/java/burp/BurpExtender.java
@@ -8,6 +8,7 @@ import java.util.List;
 
 import javax.swing.JMenuItem;
 
+import de.usd.cstchef.FilterState;
 import de.usd.cstchef.view.FormatTab;
 import de.usd.cstchef.view.RecipePanel;
 import de.usd.cstchef.view.View;
@@ -45,12 +46,12 @@ public class BurpExtender implements IBurpExtender, ITab, IMessageEditorTabFacto
 
     @Override
     public void processHttpMessage(int toolFlag, boolean messageIsRequest, IHttpRequestResponse messageInfo) {
-        if (messageIsRequest && view.getOutgoingRecipePanel().shouldProcess(toolFlag)) {
+        if (messageIsRequest && view.getFilterState().shouldProcess(toolFlag, FilterState.BurpOperation.OUTGOING)) {
             byte[] request = messageInfo.getRequest();
             byte[] modifiedRequest = view.getOutgoingRecipePanel().bake(request);
             Logger.getInstance().log("modified request: \n" + new String(modifiedRequest));
             messageInfo.setRequest(modifiedRequest);
-        } else if (view.getIncomingRecipePanel().shouldProcess(toolFlag)) {
+        } else if (view.getFilterState().shouldProcess(toolFlag, FilterState.BurpOperation.INCOMING)) {
             byte[] response = messageInfo.getResponse();
             byte[] modifiedResponse = view.getIncomingRecipePanel().bake(response);
             messageInfo.setResponse(modifiedResponse);

--- a/src/main/java/de/usd/cstchef/FilterState.java
+++ b/src/main/java/de/usd/cstchef/FilterState.java
@@ -5,7 +5,7 @@ public class FilterState {
     private int outgoingFilterMask;
     private int formatFilterMask;
 
-    FilterState(int incomingFilterMask, int outgoingFilterMask, int formatFilterMask){
+    public FilterState(int incomingFilterMask, int outgoingFilterMask, int formatFilterMask){
         this.incomingFilterMask = incomingFilterMask;
         this.outgoingFilterMask = outgoingFilterMask;
         this.formatFilterMask = formatFilterMask;

--- a/src/main/java/de/usd/cstchef/FilterState.java
+++ b/src/main/java/de/usd/cstchef/FilterState.java
@@ -3,7 +3,6 @@ package de.usd.cstchef;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
-import de.usd.cstchef.view.RequestFilterDialog;
 import de.usd.cstchef.view.RequestFilterDialog.Filter;
 
 public class FilterState {
@@ -11,35 +10,32 @@ public class FilterState {
     private LinkedHashMap<Filter, Boolean> outgoingFilterSettings;
     private LinkedHashMap<Filter, Boolean> formatFilterSettings;
 
-    private static RequestFilterDialog requestFilterDialog;
-
     public FilterState(LinkedHashMap<Filter, Boolean> incomingFilterSettings,
             LinkedHashMap<Filter, Boolean> outgoingFilterSettings,
             LinkedHashMap<Filter, Boolean> formatFilterSettings) {
         this.incomingFilterSettings = incomingFilterSettings;
         this.outgoingFilterSettings = outgoingFilterSettings;
         this.formatFilterSettings = formatFilterSettings;
-
-        requestFilterDialog = new RequestFilterDialog(this);
     }
 
     public FilterState() {
-        this.incomingFilterSettings = new LinkedHashMap<Filter, Boolean>();
-        this.outgoingFilterSettings = new LinkedHashMap<Filter, Boolean>();
-        this.formatFilterSettings = new LinkedHashMap<Filter, Boolean>();
-
-        requestFilterDialog = new RequestFilterDialog(this);
+        this(new LinkedHashMap<Filter, Boolean>(), new LinkedHashMap<Filter, Boolean>(),
+                new LinkedHashMap<Filter, Boolean>());
     }
 
     public void setFilterMask(LinkedHashMap<Filter, Boolean> filterMask, BurpOperation operation) {
-        switch(operation){
-            case INCOMING: incomingFilterSettings = filterMask;
+        switch (operation) {
+            case INCOMING:
+                incomingFilterSettings = filterMask;
                 break;
-            case OUTGOING: outgoingFilterSettings = filterMask;
+            case OUTGOING:
+                outgoingFilterSettings = filterMask;
                 break;
-            case FORMAT: formatFilterSettings = filterMask;
+            case FORMAT:
+                formatFilterSettings = filterMask;
                 break;
-            default: break;
+            default:
+                break;
         }
     }
 
@@ -102,10 +98,6 @@ public class FilterState {
             }
         }
         return (filterMask & tool) != 0;
-    }
-
-    public static RequestFilterDialog getRequestFilterDialog() {
-        return requestFilterDialog;
     }
 
     public enum BurpOperation {

--- a/src/main/java/de/usd/cstchef/FilterState.java
+++ b/src/main/java/de/usd/cstchef/FilterState.java
@@ -1,50 +1,114 @@
 package de.usd.cstchef;
 
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import de.usd.cstchef.view.RequestFilterDialog;
+import de.usd.cstchef.view.RequestFilterDialog.Filter;
+
 public class FilterState {
-    private int incomingFilterMask;
-    private int outgoingFilterMask;
-    private int formatFilterMask;
+    private LinkedHashMap<Filter, Boolean> incomingFilterSettings;
+    private LinkedHashMap<Filter, Boolean> outgoingFilterSettings;
+    private LinkedHashMap<Filter, Boolean> formatFilterSettings;
 
-    public FilterState(int incomingFilterMask, int outgoingFilterMask, int formatFilterMask){
-        this.incomingFilterMask = incomingFilterMask;
-        this.outgoingFilterMask = outgoingFilterMask;
-        this.formatFilterMask = formatFilterMask;
+    private static RequestFilterDialog requestFilterDialog;
+
+    public FilterState(LinkedHashMap<Filter, Boolean> incomingFilterSettings,
+            LinkedHashMap<Filter, Boolean> outgoingFilterSettings,
+            LinkedHashMap<Filter, Boolean> formatFilterSettings) {
+        this.incomingFilterSettings = incomingFilterSettings;
+        this.outgoingFilterSettings = outgoingFilterSettings;
+        this.formatFilterSettings = formatFilterSettings;
+
+        requestFilterDialog = new RequestFilterDialog(this);
     }
 
-    public boolean shouldProcess(int tool, BurpOperation operation) {
-        switch(operation){
-            case INCOMING: return (this.incomingFilterMask & tool) != 0;
-            case OUTGOING: return (this.incomingFilterMask & tool) != 0;
-            case FORMAT: return (this.incomingFilterMask & tool) != 0;
-            default: return false;
-        }
+    public FilterState() {
+        this.incomingFilterSettings = new LinkedHashMap<Filter, Boolean>();
+        this.outgoingFilterSettings = new LinkedHashMap<Filter, Boolean>();
+        this.formatFilterSettings = new LinkedHashMap<Filter, Boolean>();
+
+        requestFilterDialog = new RequestFilterDialog(this);
     }
 
-    public void setFilterMask(int filterMask, BurpOperation operation) {
+    public void setFilterMask(LinkedHashMap<Filter, Boolean> filterMask, BurpOperation operation) {
         switch(operation){
-            case INCOMING: incomingFilterMask = filterMask;
-            case OUTGOING: outgoingFilterMask = filterMask;
-            case FORMAT: formatFilterMask = filterMask;
+            case INCOMING: incomingFilterSettings = filterMask;
+                break;
+            case OUTGOING: outgoingFilterSettings = filterMask;
+                break;
+            case FORMAT: formatFilterSettings = filterMask;
+                break;
             default: break;
         }
     }
 
-    public void setFilterMask(int incomingFilterMask, int outgoingFilterMask, int formatFilterMask) {
-        this.incomingFilterMask = incomingFilterMask;
-        this.outgoingFilterMask = outgoingFilterMask;
-        this.formatFilterMask = formatFilterMask;
-    }
-
-     public static String translateBurpOperation(BurpOperation operation){
-        switch(operation){
-            case INCOMING: return "Incoming";
-            case OUTGOING: return "Outgoing";
-            case FORMAT: return "Formatting";
-            default: return new String();
+    public LinkedHashMap<Filter, Boolean> getFilterMask(BurpOperation operation) {
+        switch (operation) {
+            case INCOMING:
+                return incomingFilterSettings;
+            case OUTGOING:
+                return outgoingFilterSettings;
+            case FORMAT:
+                return formatFilterSettings;
+            default:
+                return new LinkedHashMap<Filter, Boolean>();
         }
     }
 
-    public enum BurpOperation{
+    public void setFilterMask(LinkedHashMap<Filter, Boolean> incomingFilterMask,
+            LinkedHashMap<Filter, Boolean> outgoingFilterMask, LinkedHashMap<Filter, Boolean> formatFilterMask) {
+        this.incomingFilterSettings = incomingFilterMask;
+        this.outgoingFilterSettings = outgoingFilterMask;
+        this.formatFilterSettings = formatFilterMask;
+    }
+
+    public static String translateBurpOperation(BurpOperation operation) {
+        switch (operation) {
+            case INCOMING:
+                return "Incoming";
+            case OUTGOING:
+                return "Outgoing";
+            case FORMAT:
+                return "Formatting";
+            default:
+                return new String();
+        }
+    }
+
+    public boolean shouldProcess(int tool, BurpOperation operation) {
+        LinkedHashMap<Filter, Boolean> filterSettings;
+        int filterMask = 0;
+        switch (operation) {
+            case INCOMING:
+                filterSettings = incomingFilterSettings;
+                break;
+            case OUTGOING:
+                filterSettings = outgoingFilterSettings;
+                break;
+            case FORMAT:
+                filterSettings = formatFilterSettings;
+                break;
+            default:
+                filterSettings = new LinkedHashMap<>();
+                break;
+        }
+
+        for (Map.Entry<Filter, Boolean> entry : filterSettings.entrySet()) {
+            Filter filter = entry.getKey();
+            boolean selected = entry.getValue();
+            if (selected) {
+                filterMask |= filter.getValue();
+            }
+        }
+        return (filterMask & tool) != 0;
+    }
+
+    public static RequestFilterDialog getRequestFilterDialog() {
+        return requestFilterDialog;
+    }
+
+    public enum BurpOperation {
         INCOMING,
         OUTGOING,
         FORMAT

--- a/src/main/java/de/usd/cstchef/FilterState.java
+++ b/src/main/java/de/usd/cstchef/FilterState.java
@@ -1,0 +1,52 @@
+package de.usd.cstchef;
+
+public class FilterState {
+    private int incomingFilterMask;
+    private int outgoingFilterMask;
+    private int formatFilterMask;
+
+    FilterState(int incomingFilterMask, int outgoingFilterMask, int formatFilterMask){
+        this.incomingFilterMask = incomingFilterMask;
+        this.outgoingFilterMask = outgoingFilterMask;
+        this.formatFilterMask = formatFilterMask;
+    }
+
+    public boolean shouldProcess(int tool, BurpOperation operation) {
+        switch(operation){
+            case INCOMING: return (this.incomingFilterMask & tool) != 0;
+            case OUTGOING: return (this.incomingFilterMask & tool) != 0;
+            case FORMAT: return (this.incomingFilterMask & tool) != 0;
+            default: return false;
+        }
+    }
+
+    public void setFilterMask(int filterMask, BurpOperation operation) {
+        switch(operation){
+            case INCOMING: incomingFilterMask = filterMask;
+            case OUTGOING: outgoingFilterMask = filterMask;
+            case FORMAT: formatFilterMask = filterMask;
+            default: break;
+        }
+    }
+
+    public void setFilterMask(int incomingFilterMask, int outgoingFilterMask, int formatFilterMask) {
+        this.incomingFilterMask = incomingFilterMask;
+        this.outgoingFilterMask = outgoingFilterMask;
+        this.formatFilterMask = formatFilterMask;
+    }
+
+     public static String translateBurpOperation(BurpOperation operation){
+        switch(operation){
+            case INCOMING: return "Incoming";
+            case OUTGOING: return "Outgoing";
+            case FORMAT: return "Formatting";
+            default: return new String();
+        }
+    }
+
+    public enum BurpOperation{
+        INCOMING,
+        OUTGOING,
+        FORMAT
+    }
+}

--- a/src/main/java/de/usd/cstchef/view/RecipePanel.java
+++ b/src/main/java/de/usd/cstchef/view/RecipePanel.java
@@ -3,7 +3,6 @@ package de.usd.cstchef.view;
 import java.awt.BorderLayout;
 import java.awt.Color;
 import java.awt.Component;
-import java.awt.Dimension;
 import java.awt.GridBagConstraints;
 import java.awt.GridBagLayout;
 import java.awt.GridLayout;
@@ -31,7 +30,6 @@ import javax.swing.JSplitPane;
 import javax.swing.JTextField;
 import javax.swing.SwingUtilities;
 import javax.swing.ToolTipManager;
-import javax.swing.UIManager;
 import javax.swing.event.ChangeEvent;
 import javax.swing.event.ChangeListener;
 import javax.swing.event.DocumentEvent;
@@ -65,7 +63,6 @@ public class RecipePanel extends JPanel implements ChangeListener {
     private int bakeThreshold = 400;
     private String recipeName;
     private BurpOperation operation;
-    private int filterMask;
 
     private BurpEditorWrapper inputText;
     private BurpEditorWrapper outputText;
@@ -145,7 +142,7 @@ public class RecipePanel extends JPanel implements ChangeListener {
 
         // add action items
         JButton filters = new JButton("Filter");
-        this.requestFilterDialog = filterState.getRequestFilterDialog();
+        this.requestFilterDialog = RequestFilterDialog.getInstance();
         activeOperationsPanel.addActionComponent(filters);
         filters.addActionListener(new ActionListener() {
             @Override

--- a/src/main/java/de/usd/cstchef/view/RecipePanel.java
+++ b/src/main/java/de/usd/cstchef/view/RecipePanel.java
@@ -145,15 +145,17 @@ public class RecipePanel extends JPanel implements ChangeListener {
 
         // add action items
         JButton filters = new JButton("Filter");
-        this.requestFilterDialog = new RequestFilterDialog();
+        this.requestFilterDialog = filterState.getRequestFilterDialog();
         activeOperationsPanel.addActionComponent(filters);
         filters.addActionListener(new ActionListener() {
             @Override
             public void actionPerformed(ActionEvent e) {
-                UIManager.put("OptionPane.minimumSize", new Dimension(300,200)); 
-                int result = JOptionPane.showConfirmDialog(null, requestFilterDialog, "Request Filter", JOptionPane.OK_CANCEL_OPTION, JOptionPane.PLAIN_MESSAGE);
+                int result = JOptionPane.showConfirmDialog(null, requestFilterDialog, "Request Filter",
+                        JOptionPane.OK_CANCEL_OPTION, JOptionPane.PLAIN_MESSAGE);
                 if (result == JOptionPane.OK_OPTION) {
-                    filterState.setFilterMask(requestFilterDialog.getFilterMask(BurpOperation.INCOMING), requestFilterDialog.getFilterMask(BurpOperation.OUTGOING), requestFilterDialog.getFilterMask(BurpOperation.FORMAT));
+                    filterState.setFilterMask(requestFilterDialog.getFilterMask(BurpOperation.INCOMING),
+                            requestFilterDialog.getFilterMask(BurpOperation.OUTGOING),
+                            requestFilterDialog.getFilterMask(BurpOperation.FORMAT));
                 }
             }
         });
@@ -226,14 +228,14 @@ public class RecipePanel extends JPanel implements ChangeListener {
             }
         });
 
-		JButton clearButton = new JButton("Clear");
-		activeOperationsPanel.addActionComponent(clearButton);
-		clearButton.addActionListener(new ActionListener() {
-			@Override
-			public void actionPerformed(ActionEvent arg0) {
-				clear();
-			}
-		});
+        JButton clearButton = new JButton("Clear");
+        activeOperationsPanel.addActionComponent(clearButton);
+        clearButton.addActionListener(new ActionListener() {
+            @Override
+            public void actionPerformed(ActionEvent arg0) {
+                clear();
+            }
+        });
 
         operationLines = new JPanel();
         operationLines.setLayout(new GridBagLayout());
@@ -286,6 +288,10 @@ public class RecipePanel extends JPanel implements ChangeListener {
 
         loadRecipeFromBurp();
         startAutoBakeTimer();
+    }
+
+    public FilterState getFilterState() {
+        return filterState;
     }
 
     private void loadRecipeFromBurp() {
@@ -343,7 +349,7 @@ public class RecipePanel extends JPanel implements ChangeListener {
 
     private void restoreState(String jsonState) throws IOException, ClassNotFoundException, InstantiationException, IllegalAccessException {
         // TODO do we want to remove all existing operations before loading here?
-		this.clear(); // Yes!
+        this.clear(); // Yes!
         ObjectMapper mapper = new ObjectMapper();
         JsonNode stepNodes = mapper.readTree(jsonState);
         if (!stepNodes.isArray()) {
@@ -364,7 +370,7 @@ public class RecipePanel extends JPanel implements ChangeListener {
                 // check if it is an operation
                 Operation op = cls.newInstance();
                 op.load(parameters);
-				op.setDisabled(!operationNode.get("is_enabled").asBoolean());
+                op.setDisabled(!operationNode.get("is_enabled").asBoolean());
                 RecipeStepPanel panel = (RecipeStepPanel) this.operationLines.getComponent(step);
                 panel.addComponent(op, i);
             }
@@ -385,7 +391,7 @@ public class RecipePanel extends JPanel implements ChangeListener {
                 operationNode.put("operation", op.getClass().getName());
                 operationsNode.add(operationNode);
                 operationNode.putPOJO("parameters", op.getState());
-				operationNode.putPOJO("is_enabled", !op.isDisabled());
+                operationNode.putPOJO("is_enabled", !op.isDisabled());
             }
             stepsNode.add(operationsNode);
         }
@@ -553,13 +559,13 @@ public class RecipePanel extends JPanel implements ChangeListener {
         } finally {
             store.unlock();
         }
-	}
+    }
 
-	private void clear() {
-		for (int step = 0; step < this.operationSteps; step++) {
-		RecipeStepPanel stepPanel = (RecipeStepPanel) this.operationLines.getComponent(step);
-			stepPanel.clearOperations();
-		} 
+    private void clear() {
+        for (int step = 0; step < this.operationSteps; step++) {
+            RecipeStepPanel stepPanel = (RecipeStepPanel) this.operationLines.getComponent(step);
+            stepPanel.clearOperations();
+        }
     }
 
     @Override
@@ -567,7 +573,4 @@ public class RecipePanel extends JPanel implements ChangeListener {
         this.autoBake();
     }
 
-    public boolean shouldProcess(int tool) {
-        return (this.filterMask & tool) != 0;
-    }
 }

--- a/src/main/java/de/usd/cstchef/view/RecipePanel.java
+++ b/src/main/java/de/usd/cstchef/view/RecipePanel.java
@@ -3,6 +3,7 @@ package de.usd.cstchef.view;
 import java.awt.BorderLayout;
 import java.awt.Color;
 import java.awt.Component;
+import java.awt.Dimension;
 import java.awt.GridBagConstraints;
 import java.awt.GridBagLayout;
 import java.awt.GridLayout;
@@ -30,6 +31,7 @@ import javax.swing.JSplitPane;
 import javax.swing.JTextField;
 import javax.swing.SwingUtilities;
 import javax.swing.ToolTipManager;
+import javax.swing.UIManager;
 import javax.swing.event.ChangeEvent;
 import javax.swing.event.ChangeListener;
 import javax.swing.event.DocumentEvent;
@@ -48,7 +50,9 @@ import burp.IHttpRequestResponse;
 import burp.IParameter;
 import burp.IRequestInfo;
 import burp.Logger;
+import de.usd.cstchef.FilterState;
 import de.usd.cstchef.VariableStore;
+import de.usd.cstchef.FilterState.BurpOperation;
 import de.usd.cstchef.operations.Operation;
 
 public class RecipePanel extends JPanel implements ChangeListener {
@@ -60,6 +64,7 @@ public class RecipePanel extends JPanel implements ChangeListener {
     private boolean isRequest = true;
     private int bakeThreshold = 400;
     private String recipeName;
+    private BurpOperation operation;
     private int filterMask;
 
     private BurpEditorWrapper inputText;
@@ -73,10 +78,14 @@ public class RecipePanel extends JPanel implements ChangeListener {
 
     private Timer bakeTimer;
 
-    public RecipePanel(String recipeName, boolean isRequest) {
+    private FilterState filterState;
 
-        this.recipeName = recipeName;
+    public RecipePanel(BurpOperation operation, boolean isRequest, FilterState filterState) {
+
+        this.operation = operation;
         this.isRequest = isRequest;
+        this.filterState = filterState;
+        this.recipeName = FilterState.translateBurpOperation(operation);
 
         ToolTipManager tooltipManager = ToolTipManager.sharedInstance();
         tooltipManager.setInitialDelay(0);
@@ -141,9 +150,10 @@ public class RecipePanel extends JPanel implements ChangeListener {
         filters.addActionListener(new ActionListener() {
             @Override
             public void actionPerformed(ActionEvent e) {
+                UIManager.put("OptionPane.minimumSize", new Dimension(300,200)); 
                 int result = JOptionPane.showConfirmDialog(null, requestFilterDialog, "Request Filter", JOptionPane.OK_CANCEL_OPTION, JOptionPane.PLAIN_MESSAGE);
                 if (result == JOptionPane.OK_OPTION) {
-                    filterMask = requestFilterDialog.getFilterMask();
+                    filterState.setFilterMask(requestFilterDialog.getFilterMask(BurpOperation.INCOMING), requestFilterDialog.getFilterMask(BurpOperation.OUTGOING), requestFilterDialog.getFilterMask(BurpOperation.FORMAT));
                 }
             }
         });

--- a/src/main/java/de/usd/cstchef/view/RequestFilterDialog.java
+++ b/src/main/java/de/usd/cstchef/view/RequestFilterDialog.java
@@ -25,8 +25,12 @@ public class RequestFilterDialog extends JPanel {
     private LinkedHashMap<Filter, Boolean> outgoingFilterSettings;
     private LinkedHashMap<Filter, Boolean> formatFilterSettings;
 
-    public RequestFilterDialog() {
+    public RequestFilterDialog(FilterState filterState) {
         this.setLayout(new GridLayout(0, 4));
+
+        incomingFilterSettings = filterState.getFilterMask(BurpOperation.INCOMING);
+        outgoingFilterSettings = filterState.getFilterMask(BurpOperation.OUTGOING);
+        formatFilterSettings = filterState.getFilterMask(BurpOperation.FORMAT);
 
         JPanel incomingPanel = createPanel(BurpOperation.INCOMING);
         JPanel outgoingPanel = createPanel(BurpOperation.OUTGOING);
@@ -35,8 +39,8 @@ public class RequestFilterDialog extends JPanel {
         JPanel labelPanel = new JPanel();
         labelPanel.setLayout(new GridLayout(7, 0));
         labelPanel.add(new JLabel(""));
-        List<String> labels = Arrays.asList("Proxy","Repeater","Spider","Scanner","Intruder","Extender");
-        for(String label : labels){
+        List<String> labels = Arrays.asList("Proxy", "Repeater", "Spider", "Scanner", "Intruder", "Extender");
+        for (String label : labels) {
             labelPanel.add(new JLabel(label));
         }
 
@@ -49,14 +53,30 @@ public class RequestFilterDialog extends JPanel {
 
     private JPanel createPanel(BurpOperation operation) {
         LinkedHashMap<Filter, Boolean> filterSettings;
-        
-        filterSettings = new LinkedHashMap<>();
-        filterSettings.put(new Filter("Proxy", IBurpExtenderCallbacks.TOOL_PROXY), false);
-        filterSettings.put(new Filter("Repeater", IBurpExtenderCallbacks.TOOL_REPEATER), false);
-        filterSettings.put(new Filter("Spider", IBurpExtenderCallbacks.TOOL_SPIDER), false);
-        filterSettings.put(new Filter("Scanner", IBurpExtenderCallbacks.TOOL_SCANNER), false);
-        filterSettings.put(new Filter("Intruder", IBurpExtenderCallbacks.TOOL_INTRUDER), false);
-        filterSettings.put(new Filter("Extender", IBurpExtenderCallbacks.TOOL_EXTENDER), false);
+
+        switch (operation) {
+            case INCOMING:
+                filterSettings = incomingFilterSettings;
+                break;
+            case OUTGOING:
+                filterSettings = outgoingFilterSettings;
+                break;
+            case FORMAT:
+                filterSettings = formatFilterSettings;
+                break;
+            default:
+                filterSettings = new LinkedHashMap<Filter, Boolean>();
+                break;
+        }
+
+        if (filterSettings.isEmpty()) {
+            filterSettings.put(new Filter("Proxy", IBurpExtenderCallbacks.TOOL_PROXY), false);
+            filterSettings.put(new Filter("Repeater", IBurpExtenderCallbacks.TOOL_REPEATER), false);
+            filterSettings.put(new Filter("Spider", IBurpExtenderCallbacks.TOOL_SPIDER), false);
+            filterSettings.put(new Filter("Scanner", IBurpExtenderCallbacks.TOOL_SCANNER), false);
+            filterSettings.put(new Filter("Intruder", IBurpExtenderCallbacks.TOOL_INTRUDER), false);
+            filterSettings.put(new Filter("Extender", IBurpExtenderCallbacks.TOOL_EXTENDER), false);
+        }
 
         JPanel panel = new JPanel();
         panel.add(new JLabel(FilterState.translateBurpOperation(operation)));
@@ -69,45 +89,44 @@ public class RequestFilterDialog extends JPanel {
             box.addActionListener(new ActionListener() {
                 @Override
                 public void actionPerformed(ActionEvent e) {
-                    filterSettings.put(filter, box.isSelected());
+                    LinkedHashMap<Filter, Boolean> filterSettings;
 
+                    switch (operation) {
+                        case INCOMING:
+                            filterSettings = incomingFilterSettings;
+                            break;
+                        case OUTGOING:
+                            filterSettings = outgoingFilterSettings;
+                            break;
+                        case FORMAT:
+                            filterSettings = formatFilterSettings;
+                            break;
+                        default:
+                            filterSettings = new LinkedHashMap<Filter, Boolean>();
+                    }
+                    filterSettings.put(filter, box.isSelected());
                 }
             });
             panel.add(box);
         }
 
-        switch (operation) {
-            case INCOMING:
-                incomingFilterSettings = filterSettings;
-            case OUTGOING:
-                outgoingFilterSettings = filterSettings;
-            case FORMAT:
-                formatFilterSettings = filterSettings;
-        }
         panel.setLayout(new GridLayout(7, 0));
         return panel;
     }
 
-    public int getFilterMask(BurpOperation operation) {
-        int filterMask = 0;
-        LinkedHashMap<Filter, Boolean> filterSettings;
-        switch (operation){
-            case INCOMING: filterSettings = incomingFilterSettings;
-            case OUTGOING: filterSettings = outgoingFilterSettings;
-            case FORMAT: filterSettings = formatFilterSettings;
-            default: filterSettings = new LinkedHashMap<>();
+    public LinkedHashMap<Filter, Boolean> getFilterMask(BurpOperation operation) {
+        if (operation == BurpOperation.INCOMING) {
+            return incomingFilterSettings;
+        } else if (operation == BurpOperation.OUTGOING) {
+            return outgoingFilterSettings;
+        } else if (operation == BurpOperation.FORMAT) {
+            return formatFilterSettings;
+        } else {
+            return new LinkedHashMap<>();
         }
-        for (Map.Entry<Filter, Boolean> entry : filterSettings.entrySet()) {
-            Filter filter = entry.getKey();
-            boolean selected = entry.getValue();
-            if (selected) {
-                filterMask |= filter.getValue();
-            }
-        }
-        return filterMask;
     }
 
-    class Filter {
+    public class Filter {
         private String name;
         private int value;
 

--- a/src/main/java/de/usd/cstchef/view/RequestFilterDialog.java
+++ b/src/main/java/de/usd/cstchef/view/RequestFilterDialog.java
@@ -1,5 +1,6 @@
 package de.usd.cstchef.view;
 
+import java.awt.BorderLayout;
 import java.awt.GridLayout;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
@@ -8,27 +9,49 @@ import java.util.Map;
 import javax.swing.JCheckBox;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
+import javax.swing.JTabbedPane;
+
+import org.objectweb.asm.Label;
 
 import burp.IBurpExtenderCallbacks;
+import de.usd.cstchef.FilterState.BurpOperation;
 
-public class RequestFilterDialog extends JPanel {
-    private LinkedHashMap<Filter, Boolean> filterSettings;
+public class RequestFilterDialog extends JTabbedPane {
+    private LinkedHashMap<Filter, Boolean> incomingFilterSettings;
+    private LinkedHashMap<Filter, Boolean> outgoingFilterSettings;
+    private LinkedHashMap<Filter, Boolean> formatFilterSettings;
 
     public RequestFilterDialog() {
-        this.filterSettings = new LinkedHashMap<>();
-        this.filterSettings.put(new Filter("Proxy", IBurpExtenderCallbacks.TOOL_PROXY), false);
-        this.filterSettings.put(new Filter("Repeater", IBurpExtenderCallbacks.TOOL_REPEATER), false);
-        this.filterSettings.put(new Filter("Spider", IBurpExtenderCallbacks.TOOL_SPIDER), false);
-        this.filterSettings.put(new Filter("Scanner", IBurpExtenderCallbacks.TOOL_SCANNER), false);
-        this.filterSettings.put(new Filter("Intruder", IBurpExtenderCallbacks.TOOL_INTRUDER), false);
-        this.filterSettings.put(new Filter("Extender", IBurpExtenderCallbacks.TOOL_EXTENDER), false);
+        JPanel incomingPanel = createPanel(BurpOperation.INCOMING);
+        JPanel outgoingPanel = createPanel(BurpOperation.OUTGOING);
+        JPanel formatPanel = createPanel(BurpOperation.FORMAT);
 
-        this.setLayout(new GridLayout(0, 2));
+        // JTabbedPane tabPane = new JTabbedPane(JTabbedPane.TOP, JTabbedPane.WRAP_TAB_LAYOUT);
 
-        for (Map.Entry<Filter, Boolean> entry : this.filterSettings.entrySet()) {
+        this.addTab("Incoming", incomingPanel);
+        this.addTab("Outgoing", outgoingPanel);
+        this.addTab("Format", formatPanel);
+
+        // this.add(tabPane, BorderLayout.CENTER);
+        
+    }
+
+    private JPanel createPanel(BurpOperation operation) {
+        LinkedHashMap<Filter, Boolean> filterSettings;
+
+        filterSettings = new LinkedHashMap<>();
+        filterSettings.put(new Filter("Proxy", IBurpExtenderCallbacks.TOOL_PROXY), false);
+        filterSettings.put(new Filter("Repeater", IBurpExtenderCallbacks.TOOL_REPEATER), false);
+        filterSettings.put(new Filter("Spider", IBurpExtenderCallbacks.TOOL_SPIDER), false);
+        filterSettings.put(new Filter("Scanner", IBurpExtenderCallbacks.TOOL_SCANNER), false);
+        filterSettings.put(new Filter("Intruder", IBurpExtenderCallbacks.TOOL_INTRUDER), false);
+        filterSettings.put(new Filter("Extender", IBurpExtenderCallbacks.TOOL_EXTENDER), false);
+
+        JPanel panel = new JPanel();
+        for (Map.Entry<Filter, Boolean> entry : filterSettings.entrySet()) {
             Filter filter = entry.getKey();
             boolean selected = entry.getValue();
-            this.add(new JLabel(filter.getName() + ": "));
+            panel.add(new JLabel(filter.getName() + ": "));
 
             JCheckBox box = new JCheckBox();
             box.setSelected(selected);
@@ -36,15 +59,34 @@ public class RequestFilterDialog extends JPanel {
                 @Override
                 public void actionPerformed(ActionEvent e) {
                     filterSettings.put(filter, box.isSelected());
+
                 }
             });
-            this.add(box);
+            panel.add(box);
         }
+
+        switch (operation) {
+            case INCOMING:
+                incomingFilterSettings = filterSettings;
+            case OUTGOING:
+                outgoingFilterSettings = filterSettings;
+            case FORMAT:
+                formatFilterSettings = filterSettings;
+        }
+        panel.setLayout(new GridLayout(0, 2));
+        return panel;
     }
 
-    public int getFilterMask() {
+    public int getFilterMask(BurpOperation operation) {
         int filterMask = 0;
-        for (Map.Entry<Filter, Boolean> entry : this.filterSettings.entrySet()) {
+        LinkedHashMap<Filter, Boolean> filterSettings;
+        switch (operation){
+            case INCOMING: filterSettings = incomingFilterSettings;
+            case OUTGOING: filterSettings = outgoingFilterSettings;
+            case FORMAT: filterSettings = formatFilterSettings;
+            default: filterSettings = new LinkedHashMap<>();
+        }
+        for (Map.Entry<Filter, Boolean> entry : filterSettings.entrySet()) {
             Filter filter = entry.getKey();
             boolean selected = entry.getValue();
             if (selected) {

--- a/src/main/java/de/usd/cstchef/view/RequestFilterDialog.java
+++ b/src/main/java/de/usd/cstchef/view/RequestFilterDialog.java
@@ -4,7 +4,10 @@ import java.awt.BorderLayout;
 import java.awt.GridLayout;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import javax.swing.JCheckBox;
 import javax.swing.JLabel;
@@ -14,31 +17,39 @@ import javax.swing.JTabbedPane;
 import org.objectweb.asm.Label;
 
 import burp.IBurpExtenderCallbacks;
+import de.usd.cstchef.FilterState;
 import de.usd.cstchef.FilterState.BurpOperation;
 
-public class RequestFilterDialog extends JTabbedPane {
+public class RequestFilterDialog extends JPanel {
     private LinkedHashMap<Filter, Boolean> incomingFilterSettings;
     private LinkedHashMap<Filter, Boolean> outgoingFilterSettings;
     private LinkedHashMap<Filter, Boolean> formatFilterSettings;
 
     public RequestFilterDialog() {
+        this.setLayout(new GridLayout(0, 4));
+
         JPanel incomingPanel = createPanel(BurpOperation.INCOMING);
         JPanel outgoingPanel = createPanel(BurpOperation.OUTGOING);
         JPanel formatPanel = createPanel(BurpOperation.FORMAT);
 
-        // JTabbedPane tabPane = new JTabbedPane(JTabbedPane.TOP, JTabbedPane.WRAP_TAB_LAYOUT);
+        JPanel labelPanel = new JPanel();
+        labelPanel.setLayout(new GridLayout(7, 0));
+        labelPanel.add(new JLabel(""));
+        List<String> labels = Arrays.asList("Proxy","Repeater","Spider","Scanner","Intruder","Extender");
+        for(String label : labels){
+            labelPanel.add(new JLabel(label));
+        }
 
-        this.addTab("Incoming", incomingPanel);
-        this.addTab("Outgoing", outgoingPanel);
-        this.addTab("Format", formatPanel);
+        this.add(labelPanel);
+        this.add("Incoming", incomingPanel);
+        this.add("Outgoing", outgoingPanel);
+        this.add("Format", formatPanel);
 
-        // this.add(tabPane, BorderLayout.CENTER);
-        
     }
 
     private JPanel createPanel(BurpOperation operation) {
         LinkedHashMap<Filter, Boolean> filterSettings;
-
+        
         filterSettings = new LinkedHashMap<>();
         filterSettings.put(new Filter("Proxy", IBurpExtenderCallbacks.TOOL_PROXY), false);
         filterSettings.put(new Filter("Repeater", IBurpExtenderCallbacks.TOOL_REPEATER), false);
@@ -48,10 +59,10 @@ public class RequestFilterDialog extends JTabbedPane {
         filterSettings.put(new Filter("Extender", IBurpExtenderCallbacks.TOOL_EXTENDER), false);
 
         JPanel panel = new JPanel();
+        panel.add(new JLabel(FilterState.translateBurpOperation(operation)));
         for (Map.Entry<Filter, Boolean> entry : filterSettings.entrySet()) {
             Filter filter = entry.getKey();
             boolean selected = entry.getValue();
-            panel.add(new JLabel(filter.getName() + ": "));
 
             JCheckBox box = new JCheckBox();
             box.setSelected(selected);
@@ -73,7 +84,7 @@ public class RequestFilterDialog extends JTabbedPane {
             case FORMAT:
                 formatFilterSettings = filterSettings;
         }
-        panel.setLayout(new GridLayout(0, 2));
+        panel.setLayout(new GridLayout(7, 0));
         return panel;
     }
 

--- a/src/main/java/de/usd/cstchef/view/RequestFilterDialog.java
+++ b/src/main/java/de/usd/cstchef/view/RequestFilterDialog.java
@@ -115,14 +115,15 @@ public class RequestFilterDialog extends JPanel {
     }
 
     public LinkedHashMap<Filter, Boolean> getFilterMask(BurpOperation operation) {
-        if (operation == BurpOperation.INCOMING) {
-            return incomingFilterSettings;
-        } else if (operation == BurpOperation.OUTGOING) {
-            return outgoingFilterSettings;
-        } else if (operation == BurpOperation.FORMAT) {
-            return formatFilterSettings;
-        } else {
-            return new LinkedHashMap<>();
+        switch (operation) {
+            case INCOMING:
+                return incomingFilterSettings;
+            case OUTGOING:
+                return outgoingFilterSettings;
+            case FORMAT:
+                return formatFilterSettings;
+            default:
+                return new LinkedHashMap<>();
         }
     }
 

--- a/src/main/java/de/usd/cstchef/view/View.java
+++ b/src/main/java/de/usd/cstchef/view/View.java
@@ -10,11 +10,15 @@ import javax.swing.WindowConstants;
 
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
 
+import de.usd.cstchef.FilterState;
+import de.usd.cstchef.FilterState.BurpOperation;
+
 public class View extends JPanel {
 
     private RecipePanel incomingRecipePanel;
     private RecipePanel outgoingRecipePanel;
     private RecipePanel formatRecipePanel;
+    private FilterState filterState;
 
     public View() {
         Security.addProvider(new BouncyCastleProvider());
@@ -22,9 +26,9 @@ public class View extends JPanel {
         this.setLayout(new BorderLayout());
         JTabbedPane tabbedPane = new JTabbedPane();
 
-        incomingRecipePanel = new RecipePanel("Incomming", false);
-        outgoingRecipePanel = new RecipePanel("Outgoing", true);
-        formatRecipePanel = new RecipePanel("Formatting", true);
+        incomingRecipePanel = new RecipePanel(BurpOperation.INCOMING, false, filterState);
+        outgoingRecipePanel = new RecipePanel(BurpOperation.OUTGOING, true, filterState);
+        formatRecipePanel = new RecipePanel(BurpOperation.FORMAT, true, filterState);
 
         tabbedPane.addTab("Outgoing Requests", null, outgoingRecipePanel, "Outgoing requests from the browser, the repeater or another tool.");
         tabbedPane.addTab("Incoming Responses", null, incomingRecipePanel, "Responses from the server.");

--- a/src/main/java/de/usd/cstchef/view/View.java
+++ b/src/main/java/de/usd/cstchef/view/View.java
@@ -2,6 +2,7 @@ package de.usd.cstchef.view;
 
 import java.awt.BorderLayout;
 import java.security.Security;
+import java.util.LinkedHashMap;
 
 import javax.swing.JFrame;
 import javax.swing.JPanel;
@@ -26,7 +27,7 @@ public class View extends JPanel {
         this.setLayout(new BorderLayout());
         JTabbedPane tabbedPane = new JTabbedPane();
 
-        filterState = new FilterState(0, 0, 0);
+        filterState = new FilterState();
 
         incomingRecipePanel = new RecipePanel(BurpOperation.INCOMING, false, filterState);
         outgoingRecipePanel = new RecipePanel(BurpOperation.OUTGOING, true, filterState);
@@ -48,6 +49,10 @@ public class View extends JPanel {
 
     public RecipePanel getFormatRecipePanel() {
         return this.formatRecipePanel;
+    }
+
+    public FilterState getFilterState(){
+        return filterState;
     }
 
     public static void main(String[] args) {

--- a/src/main/java/de/usd/cstchef/view/View.java
+++ b/src/main/java/de/usd/cstchef/view/View.java
@@ -26,6 +26,8 @@ public class View extends JPanel {
         this.setLayout(new BorderLayout());
         JTabbedPane tabbedPane = new JTabbedPane();
 
+        filterState = new FilterState(0, 0, 0);
+
         incomingRecipePanel = new RecipePanel(BurpOperation.INCOMING, false, filterState);
         outgoingRecipePanel = new RecipePanel(BurpOperation.OUTGOING, true, filterState);
         formatRecipePanel = new RecipePanel(BurpOperation.FORMAT, true, filterState);

--- a/src/main/java/de/usd/cstchef/view/View.java
+++ b/src/main/java/de/usd/cstchef/view/View.java
@@ -2,7 +2,6 @@ package de.usd.cstchef.view;
 
 import java.awt.BorderLayout;
 import java.security.Security;
-import java.util.LinkedHashMap;
 
 import javax.swing.JFrame;
 import javax.swing.JPanel;
@@ -20,6 +19,7 @@ public class View extends JPanel {
     private RecipePanel outgoingRecipePanel;
     private RecipePanel formatRecipePanel;
     private FilterState filterState;
+    private RequestFilterDialog requestFilterDialog;
 
     public View() {
         Security.addProvider(new BouncyCastleProvider());
@@ -28,6 +28,8 @@ public class View extends JPanel {
         JTabbedPane tabbedPane = new JTabbedPane();
 
         filterState = new FilterState();
+
+        requestFilterDialog = RequestFilterDialog.getInstance();
 
         incomingRecipePanel = new RecipePanel(BurpOperation.INCOMING, false, filterState);
         outgoingRecipePanel = new RecipePanel(BurpOperation.OUTGOING, true, filterState);


### PR DESCRIPTION
Updated the "Filter" selection window in the main recipe panel, so that all filters for all panels are visible and modifiable via just one popup. Users no longer have to switch tabs to set the filtering rules for specific operations.
This PR adresses [Issue #40](https://github.com/usdAG/cstc/issues/40).