### PR TITLE
Add configurable transformation types for HMAC

### DIFF
--- a/src/main/java/de/usd/cstchef/operations/hashing/Hmac.java
+++ b/src/main/java/de/usd/cstchef/operations/hashing/Hmac.java
@@ -3,19 +3,23 @@ package de.usd.cstchef.operations.hashing;
 import javax.crypto.Mac;
 import javax.crypto.spec.SecretKeySpec;
 import javax.swing.JComboBox;
+import org.bouncycastle.util.encoders.Base64;
 import org.bouncycastle.util.encoders.Hex;
 
 import burp.api.montoya.core.ByteArray;
 import de.usd.cstchef.operations.Operation;
 import de.usd.cstchef.operations.OperationCategory;
 import de.usd.cstchef.operations.Operation.OperationInfos;
-import de.usd.cstchef.view.ui.VariableTextField;
+import de.usd.cstchef.view.ui.FormatTextField;
 
 @OperationInfos(name = "HMAC", category = OperationCategory.HASHING, description = "Creates an HMAC with the chosen hashing function.")
 public class Hmac extends Operation {
 
-    private VariableTextField keyTxt;
+    private static final String[] outModes = new String[] { "Raw", "Hex", "Base64" };
+    
+    private FormatTextField keyTxt;
     private JComboBox<String> hashAlgoBox;
+    private JComboBox<String> outputMode;
 
     @Override
     protected ByteArray perform(ByteArray input) throws Exception {
@@ -24,7 +28,15 @@ public class Hmac extends Operation {
         SecretKeySpec signingKey = new SecretKeySpec(key, algo);
         Mac mac = Mac.getInstance(algo);
         mac.init(signingKey);
-        return factory.createByteArray(Hex.encode(mac.doFinal(input.getBytes())));
+        byte[] hash = mac.doFinal(input.getBytes());
+        
+        String selectedOutputMode = (String)outputMode.getSelectedItem();
+        if( selectedOutputMode.equals("Hex") )
+            hash = Hex.encode(hash);
+        if( selectedOutputMode.equals("Base64") )
+            hash = Base64.encode(hash);
+        
+        return factory.createByteArray(hash);
     }
 
     @Override
@@ -33,8 +45,11 @@ public class Hmac extends Operation {
         this.hashAlgoBox = new JComboBox<>(algorithms);
         this.addUIElement("Hashing function", this.hashAlgoBox);
 
-        this.keyTxt = new VariableTextField();
+        this.keyTxt = new FormatTextField();
         this.addUIElement("Key", this.keyTxt);
+
+        this.outputMode = new JComboBox<>(outModes);
+        this.addUIElement("Output", this.outputMode);
     }
 
 }


### PR DESCRIPTION
Hi, I found that the current HMAC operation only receives an input secret key as plain text. So I made a small change to add configurable transformation types for both the input secret key and the output. Hope you'll find this helpful.